### PR TITLE
Add architecture input to docker build workflows

### DIFF
--- a/.github/workflows/reusable_docker_build_push.yaml
+++ b/.github/workflows/reusable_docker_build_push.yaml
@@ -9,6 +9,11 @@ on:
       version:
         required: false
         type: string
+      architecture:
+        description: "Target architecture for the image (arm64 or amd64)"
+        required: false
+        default: "arm64"
+        type: string
 
 jobs:
   docker:
@@ -32,5 +37,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/${{ inputs.architecture }}
           tags: ${{ inputs.image_name }}:${{ inputs.version }}
           build-args: RELEASED_VERSION=${{ inputs.version }}

--- a/.github/workflows/reusable_pypi_docker_build_push.yaml
+++ b/.github/workflows/reusable_pypi_docker_build_push.yaml
@@ -9,6 +9,11 @@ on:
       version:
         required: false
         type: string
+      architecture:
+        description: "Target architecture for the image (arm64 or amd64)"
+        required: false
+        default: "arm64"
+        type: string
       pypi_url:
         required: true
         type: string
@@ -38,6 +43,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/${{ inputs.architecture }}
           tags: ${{ inputs.image_name }}:${{ inputs.version }}
           build-args: RELEASED_VERSION=${{ inputs.version }}
 

--- a/.github/workflows/reusable_release_docker_build_push.yaml
+++ b/.github/workflows/reusable_release_docker_build_push.yaml
@@ -6,6 +6,11 @@ on:
       image_name:
         required: true
         type: string
+      architecture:
+        description: "Target architecture for the image (arm64 or amd64)"
+        required: false
+        default: "arm64"
+        type: string
 
 jobs:
   docker:
@@ -36,5 +41,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/${{ inputs.architecture }}
           tags: ${{ inputs.image_name }}:${{ steps.release.outputs.version }}
           build-args: RELEASED_VERSION=${{ steps.release.outputs.version }}

--- a/.github/workflows/reusable_release_pypi_docker_build_push.yaml
+++ b/.github/workflows/reusable_release_pypi_docker_build_push.yaml
@@ -6,6 +6,11 @@ on:
       image_name:
         required: true
         type: string
+      architecture:
+        description: "Target architecture for the image (arm64 or amd64)"
+        required: false
+        default: "arm64"
+        type: string
       pypi_url:
         required: true
         type: string
@@ -42,6 +47,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/${{ inputs.architecture }}
           tags: ${{ inputs.image_name }}:${{ steps.release.outputs.version }}
           build-args: RELEASED_VERSION=${{ steps.release.outputs.version }}
 


### PR DESCRIPTION
Adds an `architecture` input (default `arm64`) to all four reusable docker-building workflows, wired to the `platforms` field of `docker/build-push-action`.

Affected workflows:
- `reusable_docker_build_push.yaml`
- `reusable_release_docker_build_push.yaml`
- `reusable_pypi_docker_build_push.yaml`
- `reusable_release_pypi_docker_build_push.yaml`

Callers can override with `amd64`; defaults to `arm64`.