### PR TITLE
Support poetry-dynamic-versioning in pypi publish workflows

### DIFF
--- a/.github/workflows/reusable_pypi_build_push.yaml
+++ b/.github/workflows/reusable_pypi_build_push.yaml
@@ -21,6 +21,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + tags so poetry-dynamic-versioning can derive the
+          # version from the latest git tag. Harmless for repos that still
+          # rely on the <VERSION> placeholder below.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup python
         uses: actions/setup-python@v5
@@ -29,6 +35,13 @@ jobs:
 
       - name: Setup poetry
         uses: Gr1N/setup-poetry@v8
+
+      - name: Install poetry-dynamic-versioning plugin
+        # No-op for repos that don't set `enable = true`; required for Poetry's
+        # own build/publish to apply dynamic versioning (the build-backend
+        # setting alone only covers PEP 517 frontends like pip).
+        shell: bash
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Publish package
         shell: bash
@@ -39,6 +52,8 @@ jobs:
         run: |
           for DIRECTORY in ${DIRECTORIES}; do
             pushd "${DIRECTORY}"
+            # Backward compat: substitutes the placeholder for repos still
+            # passing `version`. No-op when there's no <VERSION> (dynamic repos).
             sed -i "s/<VERSION>/${RELEASED_VERSION}/" pyproject.toml
             poetry config repositories.private_pypi "${PYPI_URL}"
             poetry publish --build --repository private_pypi

--- a/.github/workflows/reusable_pypi_docker_build_push.yaml
+++ b/.github/workflows/reusable_pypi_docker_build_push.yaml
@@ -29,6 +29,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + tags so poetry-dynamic-versioning can derive the
+          # version from the latest git tag. Harmless for repos that still
+          # rely on the <VERSION> placeholder below.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -55,11 +61,18 @@ jobs:
       - name: Setup poetry
         uses: Gr1N/setup-poetry@v8
 
+      - name: Install poetry-dynamic-versioning plugin
+        # No-op for repos that don't set `enable = true`; required for Poetry's
+        # own build/publish to apply dynamic versioning (the build-backend
+        # setting alone only covers PEP 517 frontends like pip).
+        shell: bash
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
+
       - name: Publish package
         shell: bash
         env:
           PYPI_URL: ${{ inputs.pypi_url }}
-          DIRECTORY: ${{ inputs.package_directories }}
+          DIRECTORIES: ${{ inputs.package_directories }}
           RELEASED_VERSION: ${{ inputs.version }}
         run: |
           for DIRECTORY in ${DIRECTORIES}; do

--- a/.github/workflows/reusable_release_pypi_build_push.yaml
+++ b/.github/workflows/reusable_release_pypi_build_push.yaml
@@ -25,6 +25,14 @@ jobs:
         with:
           add_tags: false
 
+      - name: Fetch release tag
+        # The Release step creates the tag on the remote; pull it locally so
+        # poetry-dynamic-versioning resolves to this release, not the previous
+        # tag. No-op for placeholder repos.
+        if: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: git fetch --tags --force
+
       - name: Setup python
         uses: actions/setup-python@v5
         if: ${{ steps.release.outputs.version }}
@@ -34,6 +42,14 @@ jobs:
       - name: Setup poetry
         uses: Gr1N/setup-poetry@v8
         if: ${{ steps.release.outputs.version }}
+
+      - name: Install poetry-dynamic-versioning plugin
+        # No-op for repos that don't set `enable = true`; required for Poetry's
+        # own build/publish to apply dynamic versioning (the build-backend
+        # setting alone only covers PEP 517 frontends like pip).
+        if: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Publish package
         if: ${{ steps.release.outputs.version }}

--- a/.github/workflows/reusable_release_pypi_docker_build_push.yaml
+++ b/.github/workflows/reusable_release_pypi_docker_build_push.yaml
@@ -41,6 +41,14 @@ jobs:
         with:
           add_tags: false
 
+      - name: Fetch release tag
+        # The Release step creates the tag on the remote; pull it locally so
+        # poetry-dynamic-versioning resolves to this release, not the previous
+        # tag. No-op for placeholder repos.
+        if: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: git fetch --tags --force
+
       - name: Build and push to registry
         uses: docker/build-push-action@v5
         if: ${{ steps.release.outputs.version }}
@@ -61,12 +69,20 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         if: ${{ steps.release.outputs.version }}
 
+      - name: Install poetry-dynamic-versioning plugin
+        # No-op for repos that don't set `enable = true`; required for Poetry's
+        # own build/publish to apply dynamic versioning (the build-backend
+        # setting alone only covers PEP 517 frontends like pip).
+        if: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
+
       - name: Publish package
         if: ${{ steps.release.outputs.version }}
         shell: bash
         env:
           PYPI_URL: ${{ inputs.pypi_url }}
-          DIRECTORY: ${{ inputs.package_directories }}
+          DIRECTORIES: ${{ inputs.package_directories }}
           RELEASED_VERSION: ${{ steps.release.outputs.version }}
         run: |
           for DIRECTORY in ${DIRECTORIES}; do


### PR DESCRIPTION
## What

Makes the four reusable workflows that run \`poetry publish\` compatible with [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning), so consuming repos can derive their package version from git tags instead of substituting a \`<VERSION>\` placeholder.

All changes are **backward-compatible**: repos still using the \`<VERSION>\` placeholder + \`version\` input keep working unchanged.

## Changes

Affected workflows:
- \`reusable_pypi_build_push.yaml\`
- \`reusable_pypi_docker_build_push.yaml\`
- \`reusable_release_pypi_build_push.yaml\`
- \`reusable_release_pypi_docker_build_push.yaml\`

Each now:
- **Checks out with \`fetch-depth: 0\` + \`fetch-tags: true\`** — dynamic versioning reads the version from git tags, which a shallow checkout omits.
- **Installs the \`poetry-dynamic-versioning\` plugin** — Poetry's own \`build\`/\`publish\` commands ignore the \`build-backend\` setting, so the plugin must be installed for the version to resolve. No-op for repos that don't set \`enable = true\`.

The \`release_*\` variants additionally:
- **Fetch tags after the in-job Release step** so the version resolves to the new release rather than the previous tag.

## Bug fix

Both \`*_docker_*\` variants set \`DIRECTORY\` (singular) in the publish step's env while the loop reads \`${DIRECTORIES}\` (plural) — so the for-loop iterated zero times and **the pypi publish never actually ran**. Fixed to \`DIRECTORIES\`. ⚠️ This changes behavior: those workflows will now publish.

## Note

The \`release_*\` variants call \`automated-release-action\` with \`add_tags: false\`. The added \`git fetch --tags\` assumes a release-backing git tag still gets created (GitHub requires a tag per release). Worth confirming on the first release.